### PR TITLE
remove trailing comma from data lines

### DIFF
--- a/Core/NbfcProbe/Program.cs
+++ b/Core/NbfcProbe/Program.cs
@@ -324,6 +324,8 @@ namespace NbfcProbe
                         sb.Append(",");
                     }
 
+                    //remove last comma
+                    sb.Remove(sb.Length - 1, 1);
                     sb.AppendLine();
                 }
 


### PR DESCRIPTION
Addresses #39 such that header row and register data rows have the same field/comma structure.

Admission: I know nothing of whatever code this is written in; I simply applied the [code used here](https://github.com/UraniumDonut/nbfc-revive/blob/master/Core/NbfcProbe/Program.cs#L310) on the header row to the register value rows as well.