### PR TITLE
Dropped OpenFlags.O_EXCL from Syscall.open call

### DIFF
--- a/Core/Plugins/StagWare.Plugins.ECLinux/ECLinux.cs
+++ b/Core/Plugins/StagWare.Plugins.ECLinux/ECLinux.cs
@@ -76,7 +76,7 @@ namespace StagWare.Plugins
 
                 if(this.stream == null)
                 {
-                    int fd = Syscall.open(PortFilePath, OpenFlags.O_RDWR | OpenFlags.O_EXCL);
+                    int fd = Syscall.open(PortFilePath, OpenFlags.O_RDWR);
 
                     if (fd == -1)
                     {

--- a/Core/Plugins/StagWare.Plugins.ECSysLinux/ECSysLinux.cs
+++ b/Core/Plugins/StagWare.Plugins.ECSysLinux/ECSysLinux.cs
@@ -111,7 +111,7 @@ namespace StagWare.Plugins.ECSysLinux
 
                 if (this.stream == null)
                 {
-                    int fd = Syscall.open(EC0IOPath, OpenFlags.O_RDWR | OpenFlags.O_EXCL);
+                    int fd = Syscall.open(EC0IOPath, OpenFlags.O_RDWR);
 
                     if (fd == -1)
                     {


### PR DESCRIPTION
According to man 2 open:

"In general, the behavior of O_EXCL is undefined if it is used without O_CREAT."