### PR TITLE
Add config for Asus Vivobook K3502

### DIFF
--- a/Configs/Asus Vivobook S15 K3502.xml
+++ b/Configs/Asus Vivobook S15 K3502.xml
@@ -10,7 +10,7 @@
       <ReadRegister>236</ReadRegister>
       <WriteRegister>236</WriteRegister>
       <MinSpeedValue>0</MinSpeedValue>
-      <MaxSpeedValue>8</MaxSpeedValue>
+      <MaxSpeedValue>9</MaxSpeedValue>
       <IndependentReadMinMaxValues>false</IndependentReadMinMaxValues>
       <MinSpeedValueRead>0</MinSpeedValueRead>
       <MaxSpeedValueRead>0</MaxSpeedValueRead>
@@ -21,32 +21,32 @@
         <TemperatureThreshold>
           <UpThreshold>0</UpThreshold>
           <DownThreshold>0</DownThreshold>
-          <FanSpeed>12.5</FanSpeed>
+          <FanSpeed>11.1111116</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>74</UpThreshold>
           <DownThreshold>70</DownThreshold>
-          <FanSpeed>25</FanSpeed>
+          <FanSpeed>22.2222233</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>81</UpThreshold>
           <DownThreshold>73</DownThreshold>
-          <FanSpeed>37.5</FanSpeed>
+          <FanSpeed>33.3333359</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>87</UpThreshold>
           <DownThreshold>80</DownThreshold>
-          <FanSpeed>50</FanSpeed>
+          <FanSpeed>44.4444466</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>91</UpThreshold>
           <DownThreshold>86</DownThreshold>
-          <FanSpeed>62.5</FanSpeed>
+          <FanSpeed>55.5555573</FanSpeed>
         </TemperatureThreshold>
         <TemperatureThreshold>
           <UpThreshold>95</UpThreshold>
           <DownThreshold>90</DownThreshold>
-          <FanSpeed>75</FanSpeed>
+          <FanSpeed>66.66667</FanSpeed>
         </TemperatureThreshold>
       </TemperatureThresholds>
       <FanSpeedPercentageOverrides />

--- a/Configs/Asus Vivobook S15 K3502.xml
+++ b/Configs/Asus Vivobook S15 K3502.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<FanControlConfigV2 xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NotebookModel>Asus Vivobook K3502</NotebookModel>
+  <Author>Strong361</Author>
+  <EcPollInterval>500</EcPollInterval>
+  <ReadWriteWords>false</ReadWriteWords>
+  <CriticalTemperature>100</CriticalTemperature>
+  <FanConfigurations>
+    <FanConfiguration>
+      <ReadRegister>236</ReadRegister>
+      <WriteRegister>236</WriteRegister>
+      <MinSpeedValue>0</MinSpeedValue>
+      <MaxSpeedValue>8</MaxSpeedValue>
+      <IndependentReadMinMaxValues>false</IndependentReadMinMaxValues>
+      <MinSpeedValueRead>0</MinSpeedValueRead>
+      <MaxSpeedValueRead>0</MaxSpeedValueRead>
+      <ResetRequired>false</ResetRequired>
+      <FanSpeedResetValue>0</FanSpeedResetValue>
+      <FanDisplayName>Fan1</FanDisplayName>
+      <TemperatureThresholds>
+        <TemperatureThreshold>
+          <UpThreshold>0</UpThreshold>
+          <DownThreshold>0</DownThreshold>
+          <FanSpeed>12.5</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>74</UpThreshold>
+          <DownThreshold>70</DownThreshold>
+          <FanSpeed>25</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>81</UpThreshold>
+          <DownThreshold>73</DownThreshold>
+          <FanSpeed>37.5</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>87</UpThreshold>
+          <DownThreshold>80</DownThreshold>
+          <FanSpeed>50</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>91</UpThreshold>
+          <DownThreshold>86</DownThreshold>
+          <FanSpeed>62.5</FanSpeed>
+        </TemperatureThreshold>
+        <TemperatureThreshold>
+          <UpThreshold>95</UpThreshold>
+          <DownThreshold>90</DownThreshold>
+          <FanSpeed>75</FanSpeed>
+        </TemperatureThreshold>
+      </TemperatureThresholds>
+      <FanSpeedPercentageOverrides />
+    </FanConfiguration>
+  </FanConfigurations>
+  <RegisterWriteConfigurations />
+</FanControlConfigV2>


### PR DESCRIPTION
Laptop Model: Asus Vivobook S15 K3502ZA-MA115W
CPU: Intel Core i5 12500H
Works without issues, but it is required to update OpenHardwareMonitorLib dll , as explained here:
https://github.com/UraniumDonut/nbfc-revive/issues/27